### PR TITLE
BugFix: Filtering & Selected Bleachers

### DIFF
--- a/src/app/(dashboards)/bleachers-dashboard/_lib/_components/dashboard/MainScrollableGrid.tsx
+++ b/src/app/(dashboards)/bleachers-dashboard/_lib/_components/dashboard/MainScrollableGrid.tsx
@@ -142,9 +142,7 @@ export default function MainScrollableGrid({
                     isFirstVisibleColumn={isFirstVisibleColumn}
                     scrollLeftRef={scrollLeftRef}
                     firstVisibleColumnRef={firstVisibleColumnRef}
-                    bleacherIds={bleachers
-                      .filter((b) => b.events.some((e) => e.eventId === event.eventId))
-                      .map((b) => b.bleacherId)}
+                    bleacherIds={event.bleacherIds}
                   />
                 ))
               ) : (

--- a/src/app/(dashboards)/bleachers-dashboard/_lib/db.ts
+++ b/src/app/(dashboards)/bleachers-dashboard/_lib/db.ts
@@ -86,6 +86,9 @@ export function fetchBleachers() {
               hslHue: event.hsl_hue,
               alerts: relatedAlerts,
               mustBeClean: event.must_be_clean,
+              bleacherIds: bleacherEvents
+                .filter((be) => be.event_id === event.event_id)
+                .map((be) => be.bleacher_id), // find all bleachers linked to this event
             };
           })
           .filter((e) => e !== null) as DashboardEvent[]; // filter out nulls
@@ -107,6 +110,7 @@ export function fetchBleachers() {
         };
       })
       .sort((a, b) => b.bleacherNumber - a.bleacherNumber);
+    // console.log("formattedBleachers", formattedBleachers);
 
     return formattedBleachers;
     // const multipliedBleachers = Array.from({ length: 100 }, (_, i) =>

--- a/src/app/(dashboards)/bleachers-dashboard/_lib/functions.ts
+++ b/src/app/(dashboards)/bleachers-dashboard/_lib/functions.ts
@@ -312,16 +312,6 @@ export function filterSortBleachers(
     ? bleachers.filter((b) => matchesFilter(b) || alwaysInclude(b))
     : bleachers.filter(matchesFilter);
 
-  // Sort selected to top if form is expanded
-  // const sortedBleachers = (
-  //   isFormExpanded
-  //     ? [
-  //         ...filteredBleachers.filter(alwaysInclude),
-  //         ...filteredBleachers.filter((b) => !alwaysInclude(b)),
-  //       ]
-  //     : filteredBleachers
-  // ).sort((a, b) => a.bleacherNumber - b.bleacherNumber);
-
   const sortedBleachers = isFormExpanded
     ? [
         ...filteredBleachers


### PR DESCRIPTION
If you had the dashboard filtered so you couldn't see all the bleachers for a particular event, it wouldn't make all the selected bleachers appear if you clicked on one. Now it does.