### PR TITLE
sales scorecard driver pay numbers fixed

### DIFF
--- a/src/features/allWorkTrackers/utils/workTrackerTemplates.ts
+++ b/src/features/allWorkTrackers/utils/workTrackerTemplates.ts
@@ -77,6 +77,11 @@ export function filtersForWorkTrackerTemplate(
 ): WorkTrackerFilters {
   const { from, to } = getPeriodDates(timeRange, period, periodStart);
 
+  // For "this" period, cap the end date at today so the work-trackers page
+  // shows the same running total as the scorecard (which reads at currentDay).
+  const today = DateTime.local().toFormat("yyyy-MM-dd");
+  const effectiveTo = period === "this" && to > today ? today : to;
+
   const base: WorkTrackerFilters = {
     isOpen: true,
     statuses: [],
@@ -90,7 +95,7 @@ export function filtersForWorkTrackerTemplate(
 
   switch (template) {
     case "driver-pay":
-      return { ...base, dateFrom: from, dateTo: to };
+      return { ...base, dateFrom: from, dateTo: effectiveTo };
   }
 }
 

--- a/src/features/scorecard/hooks/accountManager/useAccountManagerScorecard.ts
+++ b/src/features/scorecard/hooks/accountManager/useAccountManagerScorecard.ts
@@ -144,8 +144,9 @@ export function useAccountManagerScorecard(accountManagerUuid: string, userUuid:
   const driverPayChart = assembleChartData(activeRange, thisPeriodDays, lastPeriodDays, currentDay, driverPayThisCumulative, driverPayLastCumulative, getPaceForEachDay(thisPeriodDays, 0));
 
   // ── Gross Margin ──
-  const thisRevenue = revenueThisCumulative[thisPeriodDays[thisPeriodDays.length - 1]] ?? 0;
-  const thisDriverPay = driverPayThisCumulative[thisPeriodDays[thisPeriodDays.length - 1]] ?? 0;
+  // Read at currentDay so gross margin matches the same point-in-time as the other cards.
+  const thisRevenue = revenueThisCumulative[currentDay] ?? 0;
+  const thisDriverPay = driverPayThisCumulative[currentDay] ?? 0;
   const lastRevenue = revenueLastCumulative[lastPeriodDays[lastPeriodDays.length - 1]] ?? 0;
   const lastDriverPay = driverPayLastCumulative[lastPeriodDays[lastPeriodDays.length - 1]] ?? 0;
 

--- a/src/features/scorecard/hooks/overview/useGrossMarginData.ts
+++ b/src/features/scorecard/hooks/overview/useGrossMarginData.ts
@@ -20,7 +20,7 @@ type GrossMarginData = {
 };
 
 export function useGrossMarginData(): GrossMarginData {
-  const { allEvents, allWorkTrackers, activeRange, periodStart, thisPeriodDays, lastPeriodDays, getGoal, timezone } =
+  const { allEvents, allWorkTrackers, activeRange, periodStart, currentDay, thisPeriodDays, lastPeriodDays, getGoal, timezone } =
     useScorecardStatsContext();
 
   const goal = getGoal("gross_margin_percent");
@@ -53,8 +53,10 @@ export function useGrossMarginData(): GrossMarginData {
     [lastPeriodDays, allWorkTrackers, timezone],
   );
 
-  const thisRevenue = thisRevenueCumulative[thisPeriodDays[thisPeriodDays.length - 1]] ?? 0;
-  const thisDriverPay = thisDriverPayCumulative[thisPeriodDays[thisPeriodDays.length - 1]] ?? 0;
+  // Read at currentDay (not end-of-period) so gross margin matches the
+  // same point-in-time as the driver pay card and revenue card.
+  const thisRevenue = thisRevenueCumulative[currentDay] ?? 0;
+  const thisDriverPay = thisDriverPayCumulative[currentDay] ?? 0;
   const lastRevenue = lastRevenueCumulative[lastPeriodDays[lastPeriodDays.length - 1]] ?? 0;
   const lastDriverPay = lastDriverPayCumulative[lastPeriodDays[lastPeriodDays.length - 1]] ?? 0;
 


### PR DESCRIPTION
I was filtering the graph to today but all the other numbers were getting work trackers until the end of the selected period (going into the future)

I've capped all the other numbers to only look up to today.